### PR TITLE
Add feature to skip applying the className to the wrapping component

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -21,6 +21,18 @@ test("SVGInline: passes & merges className", (t) => {
   )
 })
 
+test("SVGInline: skiper outer component classname", (t) => {
+  const result = ReactDOMServer.renderToStaticMarkup(
+    <SVGInline skipOuterClass className="TestSVG" svg="<svg><g></g></svg>" />
+  )
+  t.is(
+    result,
+    "<span class=\"\"><svg class=\"SVGInline-svg "+
+      "TestSVG-svg\"" +
+    "><g></g></svg></span>"
+  )
+})
+
 test("SVGInline: parent component can be chosen by tagName", (t) => {
   const result = ReactDOMServer.renderToStaticMarkup(
     <SVGInline

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class SVGInline extends Component {
         component,
         {
           ...componentProps, // take most props
-          className: classes,
+          className: componentProps.skipOuterClass ? "" : classes,
           dangerouslySetInnerHTML: {
             __html: SVGInline.cleanupSvg(svg, cleanup).replace(
               /<svg/,


### PR DESCRIPTION
This is useful when using inline CSS libraries such as aphrodite that don't support child selectors. For example, you can define your style definition with aphrodite like normal, then use this new component prop 'skipOuterClass' along with the prop classSuffix='' as a way to target just the child svg element.
