### PR TITLE
Use standalone prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^2.4.4"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "scripts": {
     "prebabelify": "rimraf lib",
@@ -59,7 +59,12 @@
     ]
   },
   "eslintConfig": {
-    "extends": "eslint-config-i-am-meticulous/react"
+    "extends": "eslint-config-i-am-meticulous/react",
+    "rules": {
+      "comma-dangle": ["error", {
+        "objects": "always"
+      }]
+    }
   },
   "ava": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -24,20 +24,22 @@
     "ava": "^0.15.0",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",
+    "babel-eslint": "^7.2.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
-    "eslint": "^2.4.0",
-    "eslint-config-i-am-meticulous": "^3.0.0",
-    "eslint-plugin-react": "^3.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-i-am-meticulous": "^6.0.0",
+    "eslint-plugin-react": "^6.10.3",
     "npmpub": "^3.1.0",
+    "prop-types": "^15.5.7",
     "react": "^15.2.0",
     "react-addons-test-utils": "^15.2.0",
     "react-dom": "^15.2.0",
     "rimraf": "^2.4.4"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc.1"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "scripts": {
     "prebabelify": "rimraf lib",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "extends": "eslint-config-i-am-meticulous/react",
     "rules": {
       "comma-dangle": ["error", {
-        "objects": "ignore"
+        "objects": "ignore",
+        "arrays": "ignore"
       }]
     }
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "classnames": "^2.2.1"
   },
   "devDependencies": {
-    "ava": "^0.15.0",
+    "ava": "^0.19.1",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",
     "babel-eslint": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "extends": "eslint-config-i-am-meticulous/react",
     "rules": {
       "comma-dangle": ["error", {
-        "objects": "always"
+        "objects": "ignore"
       }]
     }
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "eslint": "^3.19.0",
     "eslint-config-i-am-meticulous": "^6.0.0",
+    "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.10.3",
     "npmpub": "^3.1.0",
     "prop-types": "^15.5.7",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,9 +1,8 @@
 /* eslint-disable react/no-multi-comp, react/prop-types */
-
 import test from "ava"
-
-import React, { Component } from "react"
+import React from "react"
 import ReactDOMServer from "react-dom/server"
+
 import SVGInline from ".."
 
 // const result = ?
@@ -37,13 +36,9 @@ test("SVGInline: parent component can be chosen by tagName", (t) => {
 })
 
 test("SVGInline: parent composite component can be chosen", (t) => {
-  class TestComponent extends Component {
-    render() {
-      return (
-        <div {...this.props} className="foo" />
-      )
-    }
-  }
+  const TestComponent = (props) => (
+    <div {...props} className="foo" />
+  );
 
   const result = ReactDOMServer.renderToStaticMarkup(
     <SVGInline

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const cleanups = {
   // Sketch.app shit
   sketchMSShapeGroup: / +sketch:type=\"MSShapeGroup\"/gi,
   sketchMSPage: / +sketch:type=\"MSPage\"/gi,
-  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi,
+  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi
 }
 
 // @styled(styles)
@@ -41,7 +41,7 @@ class SVGInline extends Component {
 
     let {
       cleanup,
-      height,
+      height
     } = this.props
 
     if (
@@ -72,7 +72,7 @@ class SVGInline extends Component {
     const classes = cx({
       "SVGInline": true,
       "SVGInline--cleaned": cleanup.length,
-      [className]: className,
+      [className]: className
     })
     const svgClasses = classes
       .split(" ")
@@ -101,8 +101,8 @@ class SVGInline extends Component {
                   "\""
                 : ""
               )
-            ),
-          },
+            )
+          }
         }
       )
     )
@@ -124,14 +124,14 @@ SVGInline.propTypes = {
   ]),
   cleanupExceptions: PropTypes.array,
   width: PropTypes.string,
-  height: PropTypes.string,
+  height: PropTypes.string
 }
 
 SVGInline.defaultProps = {
   component: "span",
   classSuffix: "-svg",
   cleanup: [],
-  cleanupExceptions: [],
+  cleanupExceptions: []
 }
 
 SVGInline.cleanupSvg = (svg, cleanup = []) => {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ class SVGInline extends Component {
       width,
       classSuffix,
       cleanupExceptions,
-      ...componentProps
+      ...componentProps,
     } = this.props
 
     let {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const cleanups = {
   // Sketch.app shit
   sketchMSShapeGroup: / +sketch:type=\"MSShapeGroup\"/gi,
   sketchMSPage: / +sketch:type=\"MSPage\"/gi,
-  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi
+  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi,
 }
 
 // @styled(styles)
@@ -41,7 +41,7 @@ class SVGInline extends Component {
 
     let {
       cleanup,
-      height
+      height,
     } = this.props
 
     if (
@@ -72,7 +72,7 @@ class SVGInline extends Component {
     const classes = cx({
       "SVGInline": true,
       "SVGInline--cleaned": cleanup.length,
-      [className]: className
+      [className]: className,
     })
     const svgClasses = classes
       .split(" ")
@@ -100,8 +100,8 @@ class SVGInline extends Component {
                     (height ? `height: ${height};` : "") +
                   "\""
                 : ""
-              )
-            )
+              ),
+            ),
           }
         }
       )
@@ -124,14 +124,14 @@ SVGInline.propTypes = {
   ]),
   cleanupExceptions: PropTypes.array,
   width: PropTypes.string,
-  height: PropTypes.string
+  height: PropTypes.string,
 }
 
 SVGInline.defaultProps = {
   component: "span",
   classSuffix: "-svg",
   cleanup: [],
-  cleanupExceptions: []
+  cleanupExceptions: [],
 }
 
 SVGInline.cleanupSvg = (svg, cleanup = []) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react"
+import React, { Component } from "react"
+import PropTypes from "prop-types"
 import cx from "classnames"
 
 // import styles from "./styles"
@@ -21,7 +22,7 @@ const cleanups = {
   // Sketch.app shit
   sketchMSShapeGroup: / +sketch:type=\"MSShapeGroup\"/gi,
   sketchMSPage: / +sketch:type=\"MSPage\"/gi,
-  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi,
+  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi
 }
 
 // @styled(styles)
@@ -35,12 +36,12 @@ class SVGInline extends Component {
       width,
       classSuffix,
       cleanupExceptions,
-      ...componentProps,
+      ...componentProps
     } = this.props
 
     let {
       cleanup,
-      height,
+      height
     } = this.props
 
     if (
@@ -71,7 +72,7 @@ class SVGInline extends Component {
     const classes = cx({
       "SVGInline": true,
       "SVGInline--cleaned": cleanup.length,
-      [className]: className,
+      [className]: className
     })
     const svgClasses = classes
       .split(" ")
@@ -100,8 +101,8 @@ class SVGInline extends Component {
                   "\""
                 : ""
               )
-            ),
-          },
+            )
+          }
         }
       )
     )
@@ -113,24 +114,24 @@ SVGInline.propTypes = {
   classSuffix: PropTypes.string,
   component: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.func,
+    PropTypes.func
   ]),
   svg: PropTypes.string.isRequired,
   fill: PropTypes.string,
   cleanup: PropTypes.oneOfType([
     PropTypes.bool,
-    PropTypes.array,
+    PropTypes.array
   ]),
   cleanupExceptions: PropTypes.array,
   width: PropTypes.string,
-  height: PropTypes.string,
+  height: PropTypes.string
 }
 
 SVGInline.defaultProps = {
   component: "span",
   classSuffix: "-svg",
   cleanup: [],
-  cleanupExceptions: [],
+  cleanupExceptions: []
 }
 
 SVGInline.cleanupSvg = (svg, cleanup = []) => {

--- a/src/index.js
+++ b/src/index.js
@@ -100,9 +100,9 @@ class SVGInline extends Component {
                     (height ? `height: ${height};` : "") +
                   "\""
                 : ""
-              ),
+              )
             ),
-          }
+          },
         }
       )
     )
@@ -114,13 +114,13 @@ SVGInline.propTypes = {
   classSuffix: PropTypes.string,
   component: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.func
+    PropTypes.func,
   ]),
   svg: PropTypes.string.isRequired,
   fill: PropTypes.string,
   cleanup: PropTypes.oneOfType([
     PropTypes.bool,
-    PropTypes.array
+    PropTypes.array,
   ]),
   cleanupExceptions: PropTypes.array,
   width: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const cleanups = {
   // Sketch.app shit
   sketchMSShapeGroup: / +sketch:type=\"MSShapeGroup\"/gi,
   sketchMSPage: / +sketch:type=\"MSPage\"/gi,
-  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi
+  sketchMSLayerGroup: / +sketch:type=\"MSLayerGroup\"/gi,
 }
 
 // @styled(styles)
@@ -41,7 +41,7 @@ class SVGInline extends Component {
 
     let {
       cleanup,
-      height
+      height,
     } = this.props
 
     if (
@@ -72,7 +72,7 @@ class SVGInline extends Component {
     const classes = cx({
       "SVGInline": true,
       "SVGInline--cleaned": cleanup.length,
-      [className]: className
+      [className]: className,
     })
     const svgClasses = classes
       .split(" ")
@@ -101,8 +101,8 @@ class SVGInline extends Component {
                   "\""
                 : ""
               )
-            )
-          }
+            ),
+          },
         }
       )
     )
@@ -124,14 +124,14 @@ SVGInline.propTypes = {
   ]),
   cleanupExceptions: PropTypes.array,
   width: PropTypes.string,
-  height: PropTypes.string
+  height: PropTypes.string,
 }
 
 SVGInline.defaultProps = {
   component: "span",
   classSuffix: "-svg",
   cleanup: [],
-  cleanupExceptions: []
+  cleanupExceptions: [],
 }
 
 SVGInline.cleanupSvg = (svg, cleanup = []) => {


### PR DESCRIPTION
As of React 15.5.0 importing `Component` from the main React package throws a warning. In React 16 this will be deprecated, and you are supposed to start using the standalone `prop-types` package.

I have updated the code for the component itself. I could not get the tests to pass out of the box, so I updated `eslint-config-i-am-meticulous` to 6.0.0 and `eslint` itself to 3.19.0 and added `babel-eslint`. I then squashed all complaints from `npm test`.

Thanks for creating this package.