### PR TITLE
Reading src prop also?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ class SVGInline extends Component {
       className,
       component,
       svg,
+      src,
       fill,
       width,
       classSuffix,
@@ -43,6 +44,8 @@ class SVGInline extends Component {
       cleanup,
       height,
     } = this.props
+
+    svg = svg ? svg : src;
 
     if (
       // simple way to enable entire cleanup
@@ -116,7 +119,8 @@ SVGInline.propTypes = {
     PropTypes.string,
     PropTypes.func,
   ]),
-  svg: PropTypes.string.isRequired,
+  svg: PropTypes.string,
+  src: PropTypes.string,
   fill: PropTypes.string,
   cleanup: PropTypes.oneOfType([
     PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ class SVGInline extends Component {
       height,
     } = this.props
 
+    // use svg or src prop for svg string
     svg = svg ? svg : src;
 
     if (


### PR DESCRIPTION
Hi, 

In terms of habit, I tent to use the prop "src" instead "svg". Even though I can see the reasoning behind choosing svg as prob while using it, I used src for 3 time in row and wasted at least 20 seconds in total :)

What about having both svg and src as props for getting the string data? Its not really a big deal but.. yeah. 

I would understand if the maintainer don't think this is needed.