### PR TITLE
Add title props for a11y (#9)

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -150,3 +150,31 @@ test("SVGInline: does not pass internal props to component", (t) => {
   )
 
 })
+
+test("SVGInline: should not have a title if either title or id props are not provided", (t) => {
+  const resultWithId = ReactDOMServer.renderToStaticMarkup(
+    <SVGInline svg={ "<svg><g></g></svg>" } id="MyTestId" />
+  )
+  t.is(
+    resultWithId,
+    `${ SVGInlineStart }><g></g></svg></span>`
+  )
+
+  const restultWithTitle = ReactDOMServer.renderToStaticMarkup(
+    <SVGInline svg={ "<svg><g></g></svg>" } title="My test title" />
+  )
+  t.is(
+    restultWithTitle,
+    `${ SVGInlineStart }><g></g></svg></span>`
+  )
+})
+
+test("SVGInline: includes title if title and id props are provided", (t) => {
+  const result = ReactDOMServer.renderToStaticMarkup(
+    <SVGInline svg={ "<svg><g></g></svg>" } id="MyTestId" title="My test title" />
+  )
+  t.is(
+    result,
+    `${ SVGInlineStart } aria-labelledby="MyTestId"><title id="MyTestId">My test title</title><g></g></svg></span>`
+  )
+})

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,36 @@ class SVGInline extends Component {
     const svgClasses = classes
       .split(" ")
       .join(classSuffix + " ") + classSuffix
+    let svgStr = SVGInline.cleanupSvg(svg, cleanup)
+      .replace(
+        /<svg/,
+        `<svg class="${ svgClasses }"` +
+        (
+          fill
+          ? ` fill="${ fill }"`
+          : ""
+        ) +
+        (
+          width || height
+          ? " style=\"" +
+              (width ? `width: ${width};` : "") +
+              (height ? `height: ${height};` : "") +
+            "\""
+          : ""
+        )
+      )
+    if(title && id) {
+      const p = /<svg.*?>/.exec(svgStr)
+      const { index } = p
+      const { length } = p[0]
+      const pos = index + length - 1
 
+      svgStr = svgStr.substr(0, pos)
+        + ` aria-labelledby="${id}"`
+        + svgStr.substr(pos, 1)
+        + `<title id="${id}">${title}</title>`
+        + svgStr.substr(pos + 1)
+    }
     return (
       React.createElement(
         component,
@@ -87,23 +116,7 @@ class SVGInline extends Component {
           ...componentProps, // take most props
           className: classes,
           dangerouslySetInnerHTML: {
-            __html: SVGInline.cleanupSvg(svg, cleanup).replace(
-              /<svg/,
-              `<svg class="${ svgClasses }"` +
-              (
-                fill
-                ? ` fill="${ fill }"`
-                : ""
-              ) +
-              (
-                width || height
-                ? " style=\"" +
-                    (width ? `width: ${width};` : "") +
-                    (height ? `height: ${height};` : "") +
-                  "\""
-                : ""
-              )
-            ),
+            __html: svgStr
           },
         }
       )

--- a/src/index.js
+++ b/src/index.js
@@ -98,11 +98,8 @@ class SVGInline extends Component {
         )
       )
     if(title && id) {
-      const p = /<svg.*?>/.exec(svgStr)
-      const { index } = p
-      const { length } = p[0]
-      const pos = index + length - 1
-
+      const match = /<svg.*?>/.exec(svgStr)
+      const pos = match.index + match[0].length - 1
       svgStr = svgStr.substr(0, pos)
         + ` aria-labelledby="${id}"`
         + svgStr.substr(pos, 1)

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ class SVGInline extends Component {
       svg,
       fill,
       width,
+      title,
+      id,
       classSuffix,
       cleanupExceptions,
       ...componentProps,
@@ -125,6 +127,8 @@ SVGInline.propTypes = {
   cleanupExceptions: PropTypes.array,
   width: PropTypes.string,
   height: PropTypes.string,
+  title: PropTypes.string,
+  id: PropTypes.string,
 }
 
 SVGInline.defaultProps = {


### PR DESCRIPTION
This PR attempts to resolve #9 by adding a `<title>` element inside the svg, and the `aria-labelledby` attribute to the end of the svg opening tag.