### PR TITLE
Add stroke to <svg> tag through props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ class SVGInline extends Component {
       component,
       svg,
       fill,
+      stroke,
       width,
       accessibilityLabel,
       accessibilityDesc,
@@ -88,6 +89,11 @@ class SVGInline extends Component {
         : ""
       ) +
       (
+        stroke
+        ? ` stroke="${ stroke }"`
+        : ""
+      ) +
+      (
         width || height
         ? " style=\"" +
             (width ? `width: ${width};` : "") +
@@ -138,6 +144,7 @@ SVGInline.propTypes = {
   ]),
   svg: PropTypes.string.isRequired,
   fill: PropTypes.string,
+  stroke: PropTypes.string,
   cleanup: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.array,


### PR DESCRIPTION
In addition to fill prop we can also add stroke that will work the same way as fill.