### PR TITLE
Fix accessibility for svgs with newlines.

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -187,3 +187,13 @@ test("SVGInline: includes desc element if accessibilityDesc is provided", (t) =>
     `${ SVGInlineStart }><desc>Longer accessibility description of this svg image</desc><g></g></svg></span>`
   )
 })
+
+test("SVGInline: accessibilityLabel doesn't crash on svg tag with newlines", (t) => {
+  const result1 = ReactDOMServer.renderToStaticMarkup(
+    <SVGInline svg={ "<svg \n><g></g></svg>" } accessibilityLabel="Third test title" />
+  )
+  t.is(
+    result1,
+    `${ SVGInlineStart } ${'\n'} role="img" aria-labelledby="SVGInline-3-title"><title id="SVGInline-3-title">Third test title</title><g></g></svg></span>`
+  )
+})

--- a/src/index.js
+++ b/src/index.js
@@ -98,14 +98,14 @@ class SVGInline extends Component {
     )
     let match
     if(accessibilityDesc) {
-      match = /<svg.*?>/.exec(svgStr)
+      match = /<svg(.|\n|\r\n)*?>/.exec(svgStr)
       const pos = match.index + match[0].length
       svgStr = svgStr.substr(0, pos)
       + `<desc>${accessibilityDesc}</desc>`
       + svgStr.substr(pos)
     }
     if(accessibilityLabel) {
-      match = match || /<svg.*?>/.exec(svgStr)
+      match = match || /<svg(.|\n|\r\n)*?>/.exec(svgStr)
       const pos = match.index + match[0].length - 1
       const id = `SVGInline-${SVGInline.idCount++}-title`
       svgStr = svgStr.substr(0, pos)


### PR DESCRIPTION
Without including newlines in the RegEx, match will be undefined for svgs where the tag spans multiple lines.